### PR TITLE
Ajustes na ISR

### DIFF
--- a/FinalProject/finalProject.c
+++ b/FinalProject/finalProject.c
@@ -11,20 +11,19 @@ uint8_t counter = 0;                            //Contador para saber quantos ca
 
 int main(void)
 {
-	WDTCTL = WDTPW | WDTHOLD;	// stop watchdog timer
+    WDTCTL = WDTPW | WDTHOLD;	// stop watchdog timer
     PM5CTL0 &= ~LOCKLPM5;       // Disable the GPIO power-on default high-impedance mode
 
-	//Configurar pinos dos leds
-	//Configurar UART -> UCA3 6.1 RX 6.0 TX
-
+    //Configurar pinos dos leds
     P1DIR |= BIT0 | BIT1;                           //Configuro as LED como saída
-	P1OUT &= ~(BIT0 | BIT1);                        //Inicio as LED apagadas
-
-	UART_config(38400, LSB, WITHOUT, 0, BITS8);     //Baudrate de 38400bps, LSB first, sem paridade, 1 bit de STOP e 8BITS por comunicação
+    P1OUT &= ~(BIT0 | BIT1);                        //Inicio as LED apagadas
+	
+    //Configurar UART -> UCA3 6.1 RX 6.0 TX
+    UART_config(38400, LSB, WITHOUT, 0, BITS8);     //Baudrate de 38400bps, LSB first, sem paridade, 1 bit de STOP e 8BITS por comunicação
 
     __enable_interrupt();                           //Habilito o General Interrupt Enable (GIE) no meu Status Register (R2)
 
-    UCA3IE |= (UCRXIE | UCTXIE);                    //Tive de habilitar as interrupções do RXBUF e TXBUF também na main porque mesmo habilitando
+    //UCA3IE |= (UCRXIE);                           //Tive de habilitar as interrupções do RXBUF e TXBUF também na main porque mesmo habilitando
                                                     //na chamada da função UART_config, os bits não estavam sendo "setados"
     while(1);
 }
@@ -32,55 +31,40 @@ int main(void)
 
 #pragma vector=EUSCI_A3_VECTOR
 __interrupt void UAC3ISR(void) {
-    switch(UCA3IV) {
-    case 0x00:
-    // Vector 0: No interrupts
-    break;
-    case 0x02:  // Vector 2: UCRXIFG
+	// A leitura 
+	if (UCA3RXBUF != password[counter]) {   //Se a enésima tentativa (counter) do usuário está incorreta, se estiver, reinicio a contagem
+	    counter = 0;                        //e dou toggle no LED vermelho indicando o erro
+	    P1OUT ^= BIT0;
+	}
+	else {
+	    counter++;                          //Se o byte enviado foi correto, incremento o counter indicando que +1 byte foi acertado
+	}
+	if (counter == 4) {                     //No momento em que o 4º byte correto for lido, counter será = 4 e então devo ascender o LED verde
+	    P1OUT ^= BIT1;                      //indicando que a senha correta foi inserida. Após isso zero o counter para receber uma nova tentativa
+	    counter = 0;
+	}
 
+	//  Tentando debugar através das LED e comparando com o registro no debug do CCS
+	/*
+		if (UCA3RXBUF == 0x01) {
+		    P1OUT ^= BIT0;
+		    P1OUT &= ~BIT1;
 
-        if (UCA3RXBUF != password[counter]) {   //Se a enésima tentativa (counter) do usuário está incorreta, se estiver, reinicio a contagem
-            counter = 0;                        //e dou toggle no LED vermelho indicando o erro
-            P1OUT ^= BIT0;
-        }
-        else {
-            counter++;                          //Se o byte enviado foi correto, incremento o counter indicando que +1 byte foi acertado
-        }
-        if (counter == 4) {                     //No momento em que o 4º byte correto for lido, counter será = 4 e então devo ascender o LED verde
-            P1OUT ^= BIT1;                      //indicando que a senha correta foi inserida. Após isso zero o counter para receber uma nova tentativa
-            counter = 0;
-        }
+		}
+		else if (UCA3RXBUF == 0x42) {
+		    P1OUT &= ~BIT0;
+		    P1OUT |= BIT1;
 
-        //  Tentando debugar através das LED e comparando com o registro no debug do CCS
-        /*
-                if (UCA3RXBUF == 0x01) {
-                    P1OUT ^= BIT0;
-                    P1OUT &= ~BIT1;
+		}
+		else if (UCA3RXBUF == 0x43) {
+		    P1OUT |= BIT0;
+		    P1OUT &= ~BIT1;
 
-                }
-                else if (UCA3RXBUF == 0x42) {
-                    P1OUT &= ~BIT0;
-                    P1OUT |= BIT1;
-
-                }
-                else if (UCA3RXBUF == 0x43) {
-                    P1OUT |= BIT0;
-                    P1OUT &= ~BIT1;
-
-                }
-                else {
-                    P1OUT |= BIT0;
-                    P1OUT |= BIT1;
-                }
-        */
-    break;
-    case 0x04: // Vector 4: UCTXIFG
-    break;
-    case 0x06: // Vector 6: UCSTTIFG
-    break;
-    case 0x08: // Vector 8: UCTXCPTIFG
-    break;
-    default: break;
-    }
+		}
+		else {
+		    P1OUT |= BIT0;
+		    P1OUT |= BIT1;
+		}
+	*/
 
 }


### PR DESCRIPTION
Por construção, a rotina de tratamento de interrupção (ISR) só será executada quando uma recepção acontecer e a flag será zerada na primeira leitura de UCA3RXBUF. Simplifiquei um pouco a sua ISR para deixar o código mais curto. Pelo que vi no datasheet, o baudrate inicial é 38400. Tente rodar com as modificações que eu fiz na rotina de configuração.